### PR TITLE
Fix RN complaining about being required by "ReactNative" name.

### DIFF
--- a/lib/NestedScrollView.js
+++ b/lib/NestedScrollView.js
@@ -19,6 +19,7 @@ const {
   StyleSheet,
   PointPropType,
   EdgeInsetsPropType,
+  findNodeHandle,
   requireNativeComponent,
 } = require('react-native');
 
@@ -28,8 +29,6 @@ const ColorPropType = require('react-native/Libraries/StyleSheet/ColorPropType')
 const flattenStyle = require('react-native/Libraries/StyleSheet/flattenStyle');
 const ScrollResponder = require('react-native/Libraries/Components/ScrollResponder');
 const processDecelerationRate = require('react-native/Libraries/Components/ScrollView/processDecelerationRate');
-
-const ReactNative = require('ReactNative');
 
 const dismissKeyboard = require('react-native/Libraries/Utilities/dismissKeyboard');
 const invariant = require('fbjs/lib/invariant');
@@ -358,11 +357,11 @@ const ScrollView = React.createClass({
   },
 
   getScrollableNode: function(): any {
-    return ReactNative.findNodeHandle(this._scrollViewRef);
+    return findNodeHandle(this._scrollViewRef);
   },
 
   getInnerViewNode: function(): any {
-    return ReactNative.findNodeHandle(this._innerViewRef);
+    return findNodeHandle(this._innerViewRef);
   },
 
   /**


### PR DESCRIPTION
Console warning
```
require.js:94Requiring module 'ReactNative' by name is only supported for debugging purposes and will BREAK IN PRODUCTION!
```

Tested, works as before change, except not complaining.