### PR TITLE
Fix NullPointerExeption when compiling for SDK 27

### DIFF
--- a/android/src/main/java/com/bottomsheetbehavior/RNBottomSheetBehavior.java
+++ b/android/src/main/java/com/bottomsheetbehavior/RNBottomSheetBehavior.java
@@ -270,6 +270,10 @@ public class RNBottomSheetBehavior<V extends View> extends CoordinatorLayout.Beh
       return true;
     }
 
+    if (mViewDragHelper == null) {
+      mViewDragHelper = ViewDragHelper.create(parent, mDragCallback);
+    }
+
     mViewDragHelper.processTouchEvent( event );
 
     if ( action == MotionEvent.ACTION_DOWN ) {


### PR DESCRIPTION
This should fix issue #40 
Due to a change that results in  `onLayoutChild` being called before `onTouchEvent` there will be a NullPointerException when compiling for SDK 27. In this case the `mViewDragHelper` needs to be created before calling `processTouchEvent`